### PR TITLE
解决因配置了flinkx环境变量而导致flinkx无法找到json文件的问题

### DIFF
--- a/flinkx-executor/src/main/java/com/guoliang/flinkx/executor/service/jobhandler/FlinkXConstant.java
+++ b/flinkx-executor/src/main/java/com/guoliang/flinkx/executor/service/jobhandler/FlinkXConstant.java
@@ -21,7 +21,7 @@ public class FlinkXConstant {
 
     public static final String PARAMS_CM_V_PT = "-Dpartition=%s";
 
-    public static final String DEFAULT_JSON = "jsons";
+    public static final String DEFAULT_JSON = "job/";
 
     public static final String DEFAULT_FLINKX_SH = "flinkx";
 


### PR DESCRIPTION
如果配置了flinkx的环境变量,将会使用环境变量拼接DEFAULT_JSON存放flinx的json文件, 
安装手册中使用的是job而代码中默认是jsons. 导致flinkx找不到json文件而报错